### PR TITLE
Nibabel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,5 +135,6 @@ A class like this must be implemented for each module whose input/output needs l
  * `scikit-learn`
  * `scikit-image`
  * `pillow`
+ * `nibabel` (only the data formats in submodules imported by default)
 
 However, the code example above shows how easy it is to write a class to wrap a new module - so please feel free to submit a Pull Request to make recipy work with your favourite scientific modules!

--- a/recipy/PatchScientific.py
+++ b/recipy/PatchScientific.py
@@ -41,6 +41,15 @@ class PatchPillow(PatchSimple):
     input_wrapper = create_wrapper(log_input, 0, 'Pillow')
     output_wrapper = create_wrapper(log_output, 0, 'Pillow')
 
+class PatchNIBabel(PatchSimple):
+    modulename = 'nibabel'
+
+    images = ['nifti1.Nifti1Image', 'nifti2.Nifti2Image', 'freesurfer.mghformat.MGHImage', 'spm99analyze.Spm99AnalyzeImage', 'minc1.Minc1Image', 'minc2.Minc2Image', 'analyze.AnalyzeImage', 'parrec.PARRECImage', 'spm2analyze.Spm2AnalyzeImage']
+    input_functions = [image_name + '.from_filename' for image_name in images]
+    output_functions = [image_name + '.to_filename' for image_name in images]
+
+    input_wrapper = create_wrapper(log_input, 0, 'nibabel')
+    output_wrapper = create_wrapper(log_output, 0, 'nibabel')
 
 multiple_insert(sys.meta_path, [PatchGDAL(), PatchSKLearn(), PatchSKImage(),
-                 PatchPillow()])
+                                PatchPillow(), PatchNIBabel()])


### PR DESCRIPTION
This adds support in recipy for the nibabel package (http://nipy.org/nibabel/). This package supports i/o to a large number of neuroimaging data formats. Unfortunately some of these are in submodules, which are not imported by default (and hence can not be patched without additional import commands). This patch wraps the i/o in all submodules loaded by default.