### PR TITLE
Allow running recipy as a module (python -m recipy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Then just run your script as usual, and all of the data will be logged into the 
 
 (Note the addition of `import recipy` at the beginning of script - but there are no other changes from a standard script)
 
+Alternatively, run an unmodified script with `python -m recipy SCRIPT [ARGS ...]` to enable recipy logging. This invokes recipy's module entry point, which takes care of import recipy for you, before running your script.
+
 it will produce an output called `test.npy`. To find out the details of the run which created this file you can search using
 
     ./recipy search newplot.pdf

--- a/example_script3.py
+++ b/example_script3.py
@@ -1,0 +1,18 @@
+"""
+Usage: python -m recipy example_script3.py OUTPUT.npy
+"""
+
+from __future__ import print_function
+import sys
+
+import numpy
+
+if len(sys.argv) < 2:
+    print(__doc__, file=sys.stderr)
+    sys.exit(1)
+
+arr = numpy.arange(10)
+arr = arr + 500
+# We've made a fairly big change here!
+
+numpy.save(sys.argv[1], arr)

--- a/recipy/__main__.py
+++ b/recipy/__main__.py
@@ -1,0 +1,11 @@
+# Allow any python script to run under recipy by using ::
+#
+#   python -m recipy <script>.py <args>
+
+if __name__ == '__main__':
+    from sys import argv
+    from runpy import run_path
+    # The first argument is the full path to this module so remove it
+    argv.pop(0)
+    # Run the user script
+    run_path(argv[0])

--- a/recipy/__main__.py
+++ b/recipy/__main__.py
@@ -1,11 +1,16 @@
 # Allow any python script to run under recipy by using ::
 #
-#   python -m recipy <script>.py <args>
+#   python -m recipy SCRIPT [ARGS ...]
+from __future__ import print_function
 
 if __name__ == '__main__':
-    from sys import argv
+    from sys import argv, exit, stderr
     from runpy import run_path
     # The first argument is the full path to this module so remove it
     argv.pop(0)
-    # Run the user script
-    run_path(argv[0])
+    if argv:
+        # Run the user script
+        run_path(argv[0])
+    else:
+        print("Usage: python -m recipy SCRIPT [ARGS ...]", file=stderr)
+        exit(1)

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -35,8 +35,8 @@ def log_init():
 
     # Get the path of the script we're running
     # When running python -m recipy ..., during the recipy import argument 0
-    # is -c and the script is argument 1
-    scriptpath = os.path.realpath(sys.argv[1 if sys.argv[0] == '-c' else 0])
+    # is -c (for Python 2) or -m (for Python 3) and the script is argument 1
+    scriptpath = os.path.realpath(sys.argv[1 if sys.argv[0] in ['-c', '-m'] else 0])
 
     # Get general metadata, environment info, etc
     run = {"unique_id": guid,

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -25,6 +25,17 @@ def new_run():
     log_init()
 
 def log_init():
+    # Get the path of the script we're running
+    # When running python -m recipy ..., during the recipy import argument 0
+    # is -c (for Python 2) or -m (for Python 3) and the script is argument 1
+    if sys.argv[0] in ['-c', '-m']:
+        # Has the user called python -m recipy without further arguments?
+        if len(sys.argv) < 2:
+            return
+        scriptpath = os.path.realpath(sys.argv[1])
+    else:
+        scriptpath = os.path.realpath(sys.argv[0])
+
     global RUN_ID
 
     # Open the database
@@ -32,11 +43,6 @@ def log_init():
 
     # Create the unique ID for this run
     guid = str(uuid.uuid4())
-
-    # Get the path of the script we're running
-    # When running python -m recipy ..., during the recipy import argument 0
-    # is -c (for Python 2) or -m (for Python 3) and the script is argument 1
-    scriptpath = os.path.realpath(sys.argv[1 if sys.argv[0] in ['-c', '-m'] else 0])
 
     # Get general metadata, environment info, etc
     run = {"unique_id": guid,

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -34,7 +34,9 @@ def log_init():
     guid = str(uuid.uuid4())
 
     # Get the path of the script we're running
-    scriptpath = os.path.realpath(sys.argv[0])
+    # When running python -m recipy ..., during the recipy import argument 0
+    # is -c and the script is argument 1
+    scriptpath = os.path.realpath(sys.argv[1 if sys.argv[0] == '-c' else 0])
 
     # Get general metadata, environment info, etc
     run = {"unique_id": guid,


### PR DESCRIPTION
This removes the need to add `import recipy` to the top of the script.

Running `python -m recipy SCRIPT [ARGS ...]` will import recipy and then
run the script with arguments as normal. The logic is handled in
`recipy.__main__` (which is the entry point for `python -m recipy`).