### PR TITLE
Command args

### DIFF
--- a/example_script_args.py
+++ b/example_script_args.py
@@ -1,0 +1,11 @@
+import recipy
+
+import sys
+import numpy as np
+
+start = int(sys.argv[1])
+end = int(sys.argv[2])
+
+arr = np.arange(start, end)
+
+np.save('range.npy', arr)

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -33,8 +33,10 @@ def log_init():
         if len(sys.argv) < 2:
             return
         scriptpath = os.path.realpath(sys.argv[1])
+        cmd_args = sys.argv[2:]
     else:
         scriptpath = os.path.realpath(sys.argv[0])
+        cmd_args = sys.argv[1:]
 
     global RUN_ID
 
@@ -43,7 +45,9 @@ def log_init():
 
     # Create the unique ID for this run
     guid = str(uuid.uuid4())
-
+    
+    
+    
     # Get general metadata, environment info, etc
     run = {"unique_id": guid,
         "author": getpass.getuser(),
@@ -53,7 +57,8 @@ def log_init():
         "script": scriptpath,
         "command": sys.executable,
         "environment": [platform.platform(), "python " + sys.version.split('\n')[0]],
-        "date": datetime.datetime.utcnow()}
+        "date": datetime.datetime.utcnow(),
+        "command_args": " ".join(cmd_args)}
 
     if not option_set('ignored metadata', 'git'):
         try:
@@ -72,7 +77,7 @@ def log_init():
         except (InvalidGitRepositoryError, ValueError):
             # We can't store git info for some reason, so just skip it
             pass
-
+    
     # Put basics into DB
     RUN_ID = db.insert(run)
 

--- a/recipyCmd/recipycmd.py
+++ b/recipyCmd/recipycmd.py
@@ -42,6 +42,7 @@ def print_result(r):
     template = """Run ID: {{ unique_id }}
 Created by {{ author }} on {{ date }}
 Ran {{ script }} using {{ command }}
+Using command-line arguments: {{ command_args }}
 {% if gitcommit is defined %}
 Git: commit {{ gitcommit }}, in repo {{ gitrepo }}, with origin {{ gitorigin }}
 {% endif %}


### PR DESCRIPTION
Added new functionality to log command line arguments.

This fixes issue #47. I have only tested on windows but works either with an import recipy statement at the top of the statement or with the command line arguments of -m or -c recipy.