### PR TITLE
GUI port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ This simply instructs recipy not to save `git diff` information when it records 
  * `[general]`
 	 * `debug` - print debug mesages
 	 * `quiet` - don't print any messages
+	 * `port` - specify port to use for the gui
  *  `[database]`
  	 * `path = /path/to/file.json` - set the path to the database file
  * `[ignored metadata]`

--- a/recipyCmd/recipycmd.py
+++ b/recipyCmd/recipycmd.py
@@ -17,6 +17,7 @@ Options:
   -i --id       Search based on (a fragment of) the run ID
   -v --verbose  Be verbose
   -d --diff     Show diff
+  --no-browser  Do not open browser window
   --debug       Turn on debugging mode
 
 """
@@ -117,8 +118,9 @@ def gui(args):
   port = get_free_port()
   url = "http://127.0.0.1:{0}".format(port)
 
-  # Give the application some time before it starts
-  threading.Timer(1.25, lambda: webbrowser.open(url) ).start()
+  if not args['--no-browser']:
+      # Give the application some time before it starts
+      threading.Timer(1.25, lambda: webbrowser.open(url) ).start()
 
   # Turn off reloading by setting debug = False (this also fixes starting the
   # application twice)

--- a/recipyCmd/recipycmd.py
+++ b/recipyCmd/recipycmd.py
@@ -109,10 +109,23 @@ def gui(args):
   import threading, webbrowser, socket
 
   def get_free_port():
-      s = socket.socket()
-      s.bind(('', 0))
-      port = s.getsockname()[1]
-      s.close()
+      port = None
+      for trial_port in range(9000,9005):
+          try:
+              s = socket.socket()
+              s.bind(('', trial_port))
+              s.close()
+              port = trial_port
+              break
+          except OSError:
+              # port already bound
+              pass
+      if not port:
+          # no free ports above, fall back to random
+          s = socket.socket()
+          s.bind(('', 0))
+          port = s.getsockname()[1]
+          s.close()
       return port
 
   port = get_free_port()

--- a/recipyCmd/recipycmd.py
+++ b/recipyCmd/recipycmd.py
@@ -110,7 +110,8 @@ def gui(args):
 
   def get_free_port():
       port = None
-      for trial_port in range(9000,9005):
+      base_port = config.get_gui_port()
+      for trial_port in range(base_port,base_port+5):
           try:
               s = socket.socket()
               s.bind(('', trial_port))

--- a/recipyCommon/config.py
+++ b/recipyCommon/config.py
@@ -38,3 +38,8 @@ def get_db_path():
     except Error:
         return os.path.expanduser('~/.recipy/recipyDB.json')
     
+def get_gui_port():
+    try:
+        return int(conf.get('general', 'port'))
+    except Error:
+        return 9000


### PR DESCRIPTION
- Sets the GUI port number to be fixed, 9000 by default or as set in recipyrc:
```
[general]
port = 1234
```
- Adds a `--no-browser` command-line argument consistent with other packages (e.g. Jupyter)

Closes #80 