### PR TITLE
Support for tifffile.py and for imageio

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,7 @@ A class like this must be implemented for each module whose input/output needs l
  * `scikit-image`
  * `pillow`
  * `nibabel` (only the data formats in submodules imported by default)
+ * `imageio`
+ * `tifffile`
 
 However, the code example above shows how easy it is to write a class to wrap a new module - so please feel free to submit a Pull Request to make recipy work with your favourite scientific modules!

--- a/recipy/PatchScientific.py
+++ b/recipy/PatchScientific.py
@@ -51,5 +51,24 @@ class PatchNIBabel(PatchSimple):
     input_wrapper = create_wrapper(log_input, 0, 'nibabel')
     output_wrapper = create_wrapper(log_output, 0, 'nibabel')
 
+class PatchTifffile(PatchSimple):
+    modulename = 'tifffile'
+
+    input_functions = ['imread']
+    output_functions = ['imsave']
+
+    input_wrapper = create_wrapper(log_input, 0, 'tifffile')
+    output_wrapper = create_wrapper(log_output, 0, 'tifffile')
+
+class PatchImageio(PatchSimple):
+    modulename = 'imageio'
+
+    input_functions = ['core.functions.get_reader', 'core.functions.read']
+    output_functions = ['core.functions.get_writer']
+
+    input_wrapper = create_wrapper(log_input, 0, 'imageio')
+    output_wrapper = create_wrapper(log_output, 0, 'imageio')
+
 multiple_insert(sys.meta_path, [PatchGDAL(), PatchSKLearn(),
-                                PatchNIBabel()])
+                                PatchNIBabel(), PatchTifffile(),
+                                PatchImageio()])

--- a/test/examples/test_imageio_script.py
+++ b/test/examples/test_imageio_script.py
@@ -1,0 +1,13 @@
+import recipy
+
+import imageio
+import os
+
+in_path = r'R:\Science\XFM\GaryRuben\git_repos\tmm_model\acsemble\data'
+out_path = r'C:\temp'
+
+im1 = imageio.imread(os.path.join(in_path, 'golosio_100-C.tiff'))
+im2 = imageio.imread(os.path.join(in_path, 'Ni_test_phantom2.png'))
+
+imageio.imwrite(os.path.join(out_path, 'im1.png'), im1)
+imageio.imwrite(os.path.join(out_path, 'im2.png'), im2)

--- a/test/examples/test_tifffile_script.py
+++ b/test/examples/test_tifffile_script.py
@@ -1,0 +1,11 @@
+import recipy
+
+import tifffile
+import os
+
+in_path = r'R:\Science\XFM\GaryRuben\git_repos\tmm_model\acsemble\data'
+out_path = r'C:\temp'
+
+im1 = tifffile.imread(os.path.join(in_path, 'golosio_100-C.tiff'))
+
+tifffile.imsave(os.path.join(out_path, 'im1.tiff'), im1)


### PR DESCRIPTION
Hi,

I've added patches for Christoph Gohlke's tifffile.py and for imageio. I added test scripts to the examples directory as there isn't a useful unit test pattern to follow yet. The paths in those files are tied to my system, so they are of dubious value. I included them mainly to demonstrate that I did verify that the patch logging is behaving as expected. Feel free to discard them or come back with suggestions of how you prefer tests to be implemented,

Gary