### PR TITLE
Store hash for input/output files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+
+install: "pip install -e . behave"
+
+script: "cd tests/ && behave"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ python:
 
 install: "pip install -e . behave"
 
-script: "cd tests/ && behave"
+script: "cd test/ && behave"

--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ An example configuration is:
 This simply instructs recipy not to save `git diff` information when it records metadata about a run, and also to print debug messages (which can be really useful if you're trying to work out why certain functions aren't patched). At the moment, the only possible options are:
 
  * `[general]`
-	 * `debug` - print debug mesages
+	 * `debug` - print debug messages
 	 * `quiet` - don't print any messages
 	 * `port` - specify port to use for the GUI
+ *  `[data]`
+	 * `hash_inputs` - compute and store SHA-1 hashes of input files, via `[git-hash-object](https://git-scm.com/docs/git-hash-object)`
+	 * `hash_outputs` - compute and store SHA-1 hashes of output files, via `[git-hash-object](https://git-scm.com/docs/git-hash-object)`
  *  `[database]`
  	 * `path = /path/to/file.json` - set the path to the database file
  * `[ignored metadata]`

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ This simply instructs recipy not to save `git diff` information when it records 
 	 * `quiet` - don't print any messages
 	 * `port` - specify port to use for the GUI
  *  `[data]`
-	 * `hash_inputs` - compute and store SHA-1 hashes of input files, via `[git-hash-object](https://git-scm.com/docs/git-hash-object)`
-	 * `hash_outputs` - compute and store SHA-1 hashes of output files, via `[git-hash-object](https://git-scm.com/docs/git-hash-object)`
+	 * `hash_inputs` - compute and store SHA-1 hashes of input files, via [`git-hash-object`](https://git-scm.com/docs/git-hash-object)
+	 * `hash_outputs` - compute and store SHA-1 hashes of output files, via [`git-hash-object`](https://git-scm.com/docs/git-hash-object)
  *  `[database]`
  	 * `path = /path/to/file.json` - set the path to the database file
  * `[ignored metadata]`

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -8,7 +8,7 @@ import atexit
 from traceback import format_tb
 import uuid
 
-from .version_control import add_git_info
+from .version_control import add_git_info, git_hash_object
 from recipyCommon.config import option_set
 from recipyCommon.utils import open_or_create_db
 
@@ -74,11 +74,16 @@ def log_input(filename, source):
         except:
             pass
     filename = os.path.abspath(filename)
+    if option_set('general', 'hash_data'):
+        record = (filename, git_hash_object(filename))
+    else:
+        record = filename
+
     if option_set('general', 'debug'):
-        print("Input from %s using %s" % (filename, source))
+        print("Input from %s using %s" % (record, source))
     #Update object in DB
     db = open_or_create_db()
-    db.update(append("inputs", filename, no_duplicates=True), eids=[RUN_ID])
+    db.update(append("inputs", record, no_duplicates=True), eids=[RUN_ID])
     db.close()
 
 def log_output(filename, source):
@@ -88,11 +93,16 @@ def log_output(filename, source):
         except:
             pass
     filename = os.path.abspath(filename)
+    if option_set('general', 'hash_data'):
+        record = (filename, git_hash_object(filename))
+    else:
+        record = filename
+
     if option_set('general', 'debug'):
-        print("Output to %s using %s" % (filename, source))
+        print("Output to %s using %s" % (record, source))
     #Update object in DB
     db = open_or_create_db()
-    db.update(append("outputs", filename, no_duplicates=True), eids=[RUN_ID])
+    db.update(append("outputs", record, no_duplicates=True), eids=[RUN_ID])
     db.close()
 
 def log_update(field, filename, source):

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -1,4 +1,3 @@
-import wrapt
 import os
 import datetime
 import sys
@@ -7,7 +6,6 @@ import platform
 import sys
 import atexit
 from traceback import format_tb
-from tinydb import TinyDB
 import uuid
 
 from git import Repo, InvalidGitRepositoryError
@@ -47,8 +45,6 @@ def log_init():
 
     # Create the unique ID for this run
     guid = str(uuid.uuid4())
-
-
 
     # Get general metadata, environment info, etc
     run = {"unique_id": guid,
@@ -158,11 +154,9 @@ def append(field, value, no_duplicates=False):
 # atexit functions will run on script exit (even on exception)
 @atexit.register
 def store_exit_date():
-    # Save the record with the timestamp of the script's completion.
-    db = open_or_create_db()
-
-    run = db.get(eid=RUN_ID)
+    # Update the record with the timestamp of the script's completion.
+    # We don't save the duration because it's harder to serialize a timedelta.
     exit_date = datetime.datetime.utcnow()
-
+    db = open_or_create_db()
     db.update({'exit_date': exit_date}, eids=[RUN_ID])
     db.close()

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -74,7 +74,7 @@ def log_input(filename, source):
         except:
             pass
     filename = os.path.abspath(filename)
-    if option_set('general', 'hash_data'):
+    if option_set('data', 'hash_inputs'):
         record = (filename, git_hash_object(filename))
     else:
         record = filename
@@ -150,7 +150,7 @@ def log_exit():
 @atexit.register
 def hash_outputs():
     # Writing to output files is complete; we can now compute hashes.
-    if not option_set('general', 'hash_data'):
+    if not option_set('data', 'hash_outputs'):
         return
 
     db = open_or_create_db()

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -5,6 +5,7 @@ import sys
 import getpass
 import platform
 import sys
+import atexit
 from traceback import format_tb
 from tinydb import TinyDB
 import uuid
@@ -46,9 +47,9 @@ def log_init():
 
     # Create the unique ID for this run
     guid = str(uuid.uuid4())
-    
-    
-    
+
+
+
     # Get general metadata, environment info, etc
     run = {"unique_id": guid,
         "author": getpass.getuser(),
@@ -59,6 +60,7 @@ def log_init():
         "command": sys.executable,
         "environment": [platform.platform(), "python " + sys.version.split('\n')[0]],
         "date": datetime.datetime.utcnow(),
+        "exit_date": None,  # updated at script exit
         "command_args": " ".join(cmd_args)}
 
     if not option_set('ignored metadata', 'git'):
@@ -78,7 +80,7 @@ def log_init():
         except (InvalidGitRepositoryError, ValueError):
             # We can't store git info for some reason, so just skip it
             pass
-    
+
     # Put basics into DB
     RUN_ID = db.insert(run)
 
@@ -153,3 +155,14 @@ def append(field, value, no_duplicates=False):
     return transform
 
 
+# atexit functions will run on script exit (even on exception)
+@atexit.register
+def store_exit_date():
+    # Save the record with the timestamp of the script's completion.
+    db = open_or_create_db()
+
+    run = db.get(eid=RUN_ID)
+    exit_date = datetime.datetime.utcnow()
+
+    db.update({'exit_date': exit_date}, eids=[RUN_ID])
+    db.close()

--- a/recipy/version_control.py
+++ b/recipy/version_control.py
@@ -1,11 +1,16 @@
-from git import Repo, InvalidGitRepositoryError
+from git import Git, Repo, InvalidGitRepositoryError
 
 from recipyCommon.config import option_set
 
 
+def git_hash_object(path):
+    # Evaluate git-hash-object on path (even for files outside of repo)
+    return Git().hash_object(path)
+
 def add_git_info(run, scriptpath):
     try:
         repo = Repo(scriptpath, search_parent_directories=True)
+        run["githash"] = git_hash_object(scriptpath)
         run["gitrepo"] = repo.working_dir
         run["gitcommit"] =  repo.head.commit.hexsha
         try:

--- a/recipy/version_control.py
+++ b/recipy/version_control.py
@@ -1,11 +1,14 @@
-from git import Git, Repo, InvalidGitRepositoryError
+from git import Git, Repo, GitCommandError, InvalidGitRepositoryError
 
 from recipyCommon.config import option_set
 
 
 def git_hash_object(path):
     # Evaluate git-hash-object on path (even for files outside of repo)
-    return Git().hash_object(path)
+    try:
+        return Git().hash_object(path)
+    except GitCommandError:  # e.g. file does not exist
+        return None
 
 def add_git_info(run, scriptpath):
     try:

--- a/recipy/version_control.py
+++ b/recipy/version_control.py
@@ -1,0 +1,25 @@
+from git import Repo, InvalidGitRepositoryError
+
+from recipyCommon.config import option_set
+
+
+def add_git_info(run, scriptpath):
+    try:
+        repo = Repo(scriptpath, search_parent_directories=True)
+        run["gitrepo"] = repo.working_dir
+        run["gitcommit"] =  repo.head.commit.hexsha
+        try:
+            run["gitorigin"] = repo.remotes.origin.url
+        except:
+            run["gitorigin"] = None
+
+        if not option_set('ignored metadata', 'diff'):
+            whole_diff = ''
+            diffs = repo.index.diff(None, create_patch=True)
+            for diff in diffs:
+                whole_diff += "\n\n\n" + diff.diff.decode("utf-8")
+
+            run['diff'] = whole_diff
+    except (InvalidGitRepositoryError, ValueError):
+        # We can't store git info for some reason, so just skip it
+        pass

--- a/recipyCommon/tinydb_utils.py
+++ b/recipyCommon/tinydb_utils.py
@@ -1,19 +1,19 @@
-import datetime
+from datetime import datetime
 
 from tinydb.storages import JSONStorage
 from tinydb_serialization import Serializer, SerializationMiddleware
 
 
 class DateTimeSerializer(Serializer):
-    OBJ_CLASS = datetime.datetime  # The class this serializer handles
+    OBJ_CLASS = datetime  # The class this serializer handles
+    FORMAT = '%Y-%m-%dT%H:%M:%S'
 
     def encode(self, obj):
-        return obj.strftime('%Y-%m-%dT%H:%M:%S')
+        return obj.strftime(self.FORMAT)
 
     def decode(self, s):
-        return datetime.strptime(s, '%Y-%m-%dT%H:%M:%S')
+        return datetime.strptime(s, self.FORMAT)
 
 
-
-serialization = SerializationMiddleware()
-serialization.register_serializer(DateTimeSerializer(), 'TinyDate')
+serializer = SerializationMiddleware()
+serializer.register_serializer(DateTimeSerializer(), 'TinyDate')

--- a/recipyCommon/utils.py
+++ b/recipyCommon/utils.py
@@ -3,7 +3,7 @@ import imp
 import os
 
 from tinydb import TinyDB
-from .tinydb_utils import serialization
+from .tinydb_utils import serializer
 
 from .config import get_db_path
 
@@ -12,7 +12,7 @@ def open_or_create_db(path=get_db_path()):
     if not os.path.exists(os.path.dirname(path)):
         os.mkdir(os.path.dirname(path))
 
-    db = TinyDB(path, storage=serialization)
+    db = TinyDB(path, storage=serializer)
 
     return db
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask-Script
 flask_bootstrap
 flask-wtf
 tinydb
+tinydb-serialization
 docopt
 flask-testing
 blinker

--- a/test/features/basic.feature
+++ b/test/features/basic.feature
@@ -1,11 +1,9 @@
 Feature: Basic recipy use
 
-Scenario: Run a simple test
-    Given we have recipy set up for testing
-    When we run some code
-    Then an entry should be added to the database
+Scenario: Run a script with recipy imported
+	When we run some code
+	Then an entry should be added to the database
 
-Scenario: Test running recipy as a module
-	Given we have recipy set up for testing
+Scenario: Run a script with recipy on the commandline
 	When we run some code as a module
 	Then an entry should be added to the database

--- a/test/features/basic.feature
+++ b/test/features/basic.feature
@@ -3,6 +3,7 @@ Feature: Basic recipy use
 Scenario: Run a script with recipy imported
 	When we run some code
 	Then an entry should be added to the database
+	And it should have a recorded exit date
 
 Scenario: Run a script with recipy on the commandline
 	When we run some code as a module

--- a/test/features/basic.feature
+++ b/test/features/basic.feature
@@ -8,3 +8,8 @@ Scenario: Run a script with recipy imported
 Scenario: Run a script with recipy on the commandline
 	When we run some code as a module
 	Then an entry should be added to the database
+
+Scenario: Run a script with data hashing
+	Given the user opted in to hash data
+	When we run some code
+	Then each output should have a SHA-1 hash

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+import shutil
+
+
+TESTING_CONFIG = """[database]
+path = %s
+"""
+
+def before_scenario(context, scenario):
+    # Create temporary directory to hold database
+    context.tmpdir = tempfile.mkdtemp()
+    context.db_file = os.path.join(context.tmpdir, 'DB.json')
+
+    # Write testing configuration file to current directory
+    with open('.recipyrc', 'w') as f:
+        f.write(TESTING_CONFIG % context.db_file)
+
+def after_scenario(context, scenario):
+    # Remove temporary directory holding database
+    shutil.rmtree(context.tmpdir)

--- a/test/features/steps/basic.py
+++ b/test/features/steps/basic.py
@@ -10,7 +10,7 @@ from behave_utils import get_record_from_db, run_script_and_get_id
 @given('the user opted in to hash data')
 def step_impl(context):
     with open('.recipyrc', 'a') as f:
-        f.write("[general]\nhash_data = true")
+        f.write("[data]\nhash_inputs = true\nhash_outputs = true")
 
 @when('we run some code')
 def step_impl(context):

--- a/test/features/steps/basic.py
+++ b/test/features/steps/basic.py
@@ -1,4 +1,4 @@
-from behave import when, then
+from behave import given, when, then
 
 import os, sys
 import subprocess
@@ -6,6 +6,11 @@ from datetime import datetime
 
 from behave_utils import get_record_from_db, run_script_and_get_id
 
+
+@given('the user opted in to hash data')
+def step_impl(context):
+    with open('.recipyrc', 'a') as f:
+        f.write("[general]\nhash_data = true")
 
 @when('we run some code')
 def step_impl(context):
@@ -25,3 +30,9 @@ def step_impl(context):
 def step_impl(context):
     run = get_record_from_db(context.run_id, context.db_file)[0]
     assert type(run.get('exit_date')) is datetime
+
+@then('each output should have a SHA-1 hash')
+def step_impl(context):
+    run = get_record_from_db(context.run_id, context.db_file)[0]
+    for filename, sha1 in run.get('outputs'):
+        assert len(sha1) == 40

--- a/test/features/steps/basic.py
+++ b/test/features/steps/basic.py
@@ -3,7 +3,7 @@ from behave import when, then
 import os, sys
 import subprocess
 
-from behave_utils import check_id_exists_in_db, run_script_and_get_id
+from behave_utils import get_record_from_db, run_script_and_get_id
 
 
 @when('we run some code')
@@ -17,4 +17,11 @@ def step_impl(context):
 
 @then('an entry should be added to the database')
 def step_impl(context):
-    check_id_exists_in_db(context.run_id, context.db_file)
+    res = get_record_from_db(context.run_id, context.db_file)
+    assert len(res) == 1
+
+@then('it should have a recorded exit date')
+def step_impl(context):
+    run = get_record_from_db(context.run_id, context.db_file)[0]
+    assert 'exit_date' in run
+    assert run['exit_date'] is not None

--- a/test/features/steps/basic.py
+++ b/test/features/steps/basic.py
@@ -1,15 +1,10 @@
-from behave import given, when, then
+from behave import when, then
 
 import os, sys
 import subprocess
 
-from behave_utils import ( setup_testing_environment, check_id_exists_in_db,
-                           run_script_and_get_id )
+from behave_utils import check_id_exists_in_db, run_script_and_get_id
 
-
-@given('we have recipy set up for testing')
-def step_impl(context):
-    context.db_file = setup_testing_environment("/Users/robin/code/recipy/test/scratch/")
 
 @when('we run some code')
 def step_impl(context):

--- a/test/features/steps/basic.py
+++ b/test/features/steps/basic.py
@@ -2,6 +2,7 @@ from behave import when, then
 
 import os, sys
 import subprocess
+from datetime import datetime
 
 from behave_utils import get_record_from_db, run_script_and_get_id
 
@@ -23,5 +24,4 @@ def step_impl(context):
 @then('it should have a recorded exit date')
 def step_impl(context):
     run = get_record_from_db(context.run_id, context.db_file)[0]
-    assert 'exit_date' in run
-    assert run['exit_date'] is not None
+    assert type(run.get('exit_date')) is datetime

--- a/test/features/steps/behave_utils.py
+++ b/test/features/steps/behave_utils.py
@@ -1,18 +1,13 @@
 import os, sys, subprocess
 from tinydb import TinyDB, where
 
+from recipyCommon.tinydb_utils import serialization
 
 def get_record_from_db(id, dbfile):
-    db = TinyDB(dbfile)
-
+    db = TinyDB(dbfile, storage=serialization)
     res = db.search(where('unique_id') == id)
 
     return res
-
-def check_id_exists_in_db(id, dbfile):
-    res = get_record_from_db(id, dbfile)
-
-    assert len(res) == 1
 
 def run_script_and_get_id(script):
     output = subprocess.check_output([sys.executable, script], env={'PYTHONPATH': os.path.abspath('../')}).decode('utf-8')

--- a/test/features/steps/behave_utils.py
+++ b/test/features/steps/behave_utils.py
@@ -1,26 +1,6 @@
-import os, sys, shutil, subprocess
+import os, sys, subprocess
 from tinydb import TinyDB, where
 
-TESTING_CONFIG = """[database]
-path = %s
-"""
-
-def setup_testing_environment(path):
-    # Remove the dir if it exists already
-    if os.path.exists(path):
-        shutil.rmtree(path)
-
-    # Make the directory first
-    os.makedirs(path)
-
-    db_file = os.path.join(path, 'DB.json')
-    config_file_contents = TESTING_CONFIG % db_file
-
-    # Write testing configuration file
-    with open('/Users/robin/code/recipy/test/.recipyrc', 'w') as f:
-        f.write(config_file_contents)
-
-    return db_file
 
 def get_record_from_db(id, dbfile):
     db = TinyDB(dbfile)

--- a/test/features/steps/behave_utils.py
+++ b/test/features/steps/behave_utils.py
@@ -1,10 +1,10 @@
 import os, sys, subprocess
 from tinydb import TinyDB, where
 
-from recipyCommon.tinydb_utils import serialization
+from recipyCommon.tinydb_utils import serializer
 
 def get_record_from_db(id, dbfile):
-    db = TinyDB(dbfile, storage=serialization)
+    db = TinyDB(dbfile, storage=serializer)
     res = db.search(where('unique_id') == id)
 
     return res


### PR DESCRIPTION
Addresses issue #25. Hashes are computed using git-hash-object (SHA-1 internally). A script exit hook computes hashes after all writes must be complete. Not enabled by default, in case inputs/outputs are prohibitively large, but can be enabled with config file parameters.

I also added a Travis CI config file to run behave tests (issue #63).