### PR TITLE
adds check for $EDITOR for the annotate command

### DIFF
--- a/recipyCmd/recipycmd.py
+++ b/recipyCmd/recipycmd.py
@@ -114,6 +114,11 @@ def main():
     annotate(args)
 
 def annotate(args):
+  # check that $EDITOR is defined
+  if os.environ.get('EDITOR') is None:
+    print('No environment variable $EDITOR defined, exiting.')
+    return
+
   # Grab latest run from the DB
   run = get_latest_run()
 


### PR DESCRIPTION
If $EDITOR is not defined, running annotate results in:

```
sh: 1: /tmp/tmp2LcDL9: Permission denied
No annotation entered, exiting.
```
This commit changes that to a helpful error message.