### PR TITLE
Fixed bug #168. add_svn_info try_except catches SvnException which Py…

### DIFF
--- a/recipyCommon/version_control.py
+++ b/recipyCommon/version_control.py
@@ -80,6 +80,6 @@ def add_svn_info(run, scriptpath):
         run["svncommit"] = svn_info["commit_revision"]
         if not option_set('ignored metadata', 'diff'):
             run['diff'] = svn_diff(svn_info["wc-info/wcroot-abspath"])
-    except (SvnException, ValueError, OSError):
+    except (svn.common.SvnException, ValueError, OSError):
         # We can't access svn info for some reason, so just skip it
         pass


### PR DESCRIPTION
…thon assumes means the SvnException declaration earlier in the module when it should catch svn.common.SvnException from svn package functions
