### PR TITLE
Support for Jupyter notebooks

### DIFF
--- a/TestRecipyMagic.ipynb
+++ b/TestRecipyMagic.ipynb
@@ -2,9 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -36,13 +36,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "var kernel = IPython.notebook.kernel;\n",
+       "var attribs = document.body.attributes;\n",
+       "var command = \"recipyNotebookName = \" + \"'\"+attribs['data-notebook-name'].value+\"'\";\n",
+       "console.log(\"Load notebook name...\")\n",
+       "kernel.execute(command);"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "!recipy search test.npy"
+    "%loadNotebookName"
    ]
   },
   {
@@ -52,13 +70,53 @@
     "collapsed": false
    },
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No results found\r\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!./recipy-cmd search test.npy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[RecipyMagic] this is when recipy should bet imported, not before...\n",
+      "[RecipyMagic] notebookName: TestRecipyMagic.ipynb\n",
+      "recipy run inserted, with ID 04a14e50-7447-400d-91aa-428090ae1850\n",
+      "recipy run inserted, with ID 12edf0d4-6b89-4645-8c37-57f5061f282b\n"
+     ]
+    }
+   ],
    "source": [
     "%recipyOn"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -69,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -83,18 +141,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No results found\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
    "source": [
-    "!recipy search test.npy"
+    "!./recipy-cmd search test.npy"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -105,14 +172,51 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mRun ID:\u001b[0m 12edf0d4-6b89-4645-8c37-57f5061f282b\r\n",
+      "\u001b[1mCreated by\u001b[0m neocarlitos on 2017-01-16 20:00:21 UTC\r\n",
+      "\u001b[1mRan\u001b[0m TestRecipyMagic.ipynb using /home/neocarlitos/workspace/Python/recipy/venv/bin/python\r\n",
+      "Using command-line arguments: -f /run/user/1000/jupyter/kernel-b2e338b7-9803-4eb7-bf93-3cd1f65af266.json\r\n",
+      "\u001b[1mEnvironment:\u001b[0m Linux-4.7.9-200.fc24.x86_64-x86_64-with-fedora-24-Twenty_Four, python 2.7.12 (default, Sep 29 2016, 13:30:34) \r\n",
+      "\u001b[1mLibraries:\u001b[0m recipy v0.3.0, numpy v1.11.2\r\n",
+      "\u001b[1mInputs:\u001b[0m none\r\n",
+      "\u001b[1mOutputs:\u001b[0m\r\n",
+      "/home/neocarlitos/workspace/Python/recipy/test.npy (377cfed96fd58963783e45607b9234584c33d551)\r\n",
+      "\r\n",
+      "\r\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!./recipy-cmd search test.npy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
-   "source": [
-    "!recipy search test.npy"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/TestRecipyMagic.ipynb
+++ b/TestRecipyMagic.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!rm ~/.recipy/recipyDB.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext recipyCommon.magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!recipy search test.npy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%recipyOn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "arr = numpy.arange(10)\n",
+    "arr = arr + 500\n",
+    "\n",
+    "numpy.save('test.npy', arr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!recipy search test.npy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%recipyOff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!recipy search test.npy"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/TestRecipyMagic.ipynb
+++ b/TestRecipyMagic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -36,29 +36,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "var kernel = IPython.notebook.kernel;\n",
-       "var attribs = document.body.attributes;\n",
-       "var command = \"recipyNotebookName = \" + \"'\"+attribs['data-notebook-name'].value+\"'\";\n",
-       "console.log(\"Load notebook name...\")\n",
-       "kernel.execute(command);"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%loadNotebookName"
    ]
@@ -74,49 +56,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "No results found\r\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!./recipy-cmd search test.npy"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[RecipyMagic] this is when recipy should bet imported, not before...\n",
-      "[RecipyMagic] notebookName: TestRecipyMagic.ipynb\n",
-      "recipy run inserted, with ID 04a14e50-7447-400d-91aa-428090ae1850\n",
-      "recipy run inserted, with ID 12edf0d4-6b89-4645-8c37-57f5061f282b\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%recipyOn"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -127,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -141,27 +103,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "No results found\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!./recipy-cmd search test.npy"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -172,30 +125,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1mRun ID:\u001b[0m 12edf0d4-6b89-4645-8c37-57f5061f282b\r\n",
-      "\u001b[1mCreated by\u001b[0m neocarlitos on 2017-01-16 20:00:21 UTC\r\n",
-      "\u001b[1mRan\u001b[0m TestRecipyMagic.ipynb using /home/neocarlitos/workspace/Python/recipy/venv/bin/python\r\n",
-      "Using command-line arguments: -f /run/user/1000/jupyter/kernel-b2e338b7-9803-4eb7-bf93-3cd1f65af266.json\r\n",
-      "\u001b[1mEnvironment:\u001b[0m Linux-4.7.9-200.fc24.x86_64-x86_64-with-fedora-24-Twenty_Four, python 2.7.12 (default, Sep 29 2016, 13:30:34) \r\n",
-      "\u001b[1mLibraries:\u001b[0m recipy v0.3.0, numpy v1.11.2\r\n",
-      "\u001b[1mInputs:\u001b[0m none\r\n",
-      "\u001b[1mOutputs:\u001b[0m\r\n",
-      "/home/neocarlitos/workspace/Python/recipy/test.npy (377cfed96fd58963783e45607b9234584c33d551)\r\n",
-      "\r\n",
-      "\r\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!./recipy-cmd search test.npy"
    ]

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -16,7 +16,7 @@ import codecs
 from binaryornot.check import is_binary
 
 from recipyCommon.version_control import add_git_info, add_svn_info, hash_file
-from recipyCommon.config import option_set, get_db_path
+from recipyCommon.config import option_set, get_db_path, get_notebook_mode
 from recipyCommon.utils import open_or_create_db
 from recipyCommon.libraryversions import get_version
 
@@ -36,18 +36,23 @@ def log_init(notebookName=None):
 
     This is called when running `import recipy`.
     """
+    notebookMode = get_notebook_mode()
+    if notebookMode and notebookName is None:
+        # Avoid first call without Notebook name
+        return
+
+    if notebookMode:
+        scriptpath = notebookName
+        cmd_args = sys.argv[1:]
     # Get the path of the script we're running
     # When running python -m recipy ..., during the recipy import argument 0
     # is -c (for Python 2) or -m (for Python 3) and the script is argument 1
-    if sys.argv[0] in ['-c', '-m']:
+    elif sys.argv[0] in ['-c', '-m']:
         # Has the user called python -m recipy without further arguments?
         if len(sys.argv) < 2:
             return
         scriptpath = os.path.realpath(sys.argv[1])
         cmd_args = sys.argv[2:]
-    elif notebookName is not None:
-        scriptpath = notebookName
-        cmd_args = sys.argv[1:]
     else:
         scriptpath = os.path.realpath(sys.argv[0])
         cmd_args = sys.argv[1:]
@@ -77,10 +82,10 @@ def log_init(notebookName=None):
         "custom_values": {}
     }
 
-    if not option_set('ignored metadata', 'git'):
+    if not notebookName and not option_set('ignored metadata', 'git'):
         add_git_info(run, scriptpath)
 
-    if not option_set('ignored metadata', 'svn'):
+    if not notebookName and not option_set('ignored metadata', 'svn'):
         add_svn_info(run, scriptpath)
 
 

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -266,6 +266,12 @@ def add_dict(field, dict_of_values):
 
 # atexit functions will run on script exit (even on exception)
 @atexit.register
+def log_flush():
+    log_exit()
+    hash_outputs()
+    output_file_diffs()
+
+
 def log_exit():
     # Update the record with the timestamp of the script's completion.
     # We don't save the duration because it's harder to serialize a timedelta.
@@ -277,7 +283,6 @@ def log_exit():
     db.close()
 
 
-@atexit.register
 def hash_outputs():
     # Writing to output files is complete; we can now compute hashes.
     if option_set('ignored metadata', 'output_hashes'):
@@ -291,7 +296,6 @@ def hash_outputs():
     db.close()
 
 
-@atexit.register
 def output_file_diffs():
     # Writing to output files is complete; we can now compute file diffs.
     if not option_set('data', 'file_diff_outputs'):

--- a/recipy/log.py
+++ b/recipy/log.py
@@ -28,7 +28,7 @@ def new_run():
     log_init()
 
 
-def log_init():
+def log_init(notebookName=None):
     """Do the initial logging for a new run.
 
     Works out what script has been run, creates a new unique run ID,
@@ -45,6 +45,9 @@ def log_init():
             return
         scriptpath = os.path.realpath(sys.argv[1])
         cmd_args = sys.argv[2:]
+    elif notebookName is not None:
+        scriptpath = notebookName
+        cmd_args = sys.argv[1:]
     else:
         scriptpath = os.path.realpath(sys.argv[0])
         cmd_args = sys.argv[1:]

--- a/recipyCommon/config.py
+++ b/recipyCommon/config.py
@@ -91,3 +91,12 @@ def get_gui_port():
         return int(conf.get('general', 'port'))
     except Error:
         return 9000
+
+_notebookMode = False
+
+def get_notebook_mode():
+    return _notebookMode
+
+def set_notebook_mode(mode):
+    global _notebookMode
+    _notebookMode = mode

--- a/recipyCommon/magic.py
+++ b/recipyCommon/magic.py
@@ -2,6 +2,8 @@ from IPython.core.magic import (Magics, magics_class, line_magic,
                                 cell_magic, line_cell_magic)
 import time
 
+from recipyCommon.config import set_notebook_mode
+
 # The class MUST call this class decorator at creation time
 @magics_class
 class RecipyMagic(Magics):
@@ -20,8 +22,6 @@ console.log("Load notebook name...")
 kernel.execute(command);
 '''
         r = self.shell.run_cell(cell)
-        # x = 1/0
-        #return None
         return r
 
     def getNotebookName(self):
@@ -32,6 +32,7 @@ kernel.execute(command);
             else:
                 retries -= 1
                 time.sleep(1)
+
         return None
 
 
@@ -48,11 +49,14 @@ kernel.execute(command);
         "my line magic"
         # print("Full access to the main IPython object:", self.shell)
         # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
+        set_notebook_mode(True)
+
         notebookName = self.getNotebookName()
-        print("[RecipyMagic] this is when recipy should bet imported, not before...")
-        print("[RecipyMagic] notebookName: " + notebookName)
+        if notebookName is None:
+            print("[Recipy] Warning! Unable to get notebook name! Try running notebook step by step")
+            notebookName = "<unknown-notebook>"
         import recipy
-        recipy.log_init(notebookName='TestRecipyMagic.ipynb')
+        recipy.log_init(notebookName=notebookName)
         self.recipyModule = recipy
         return None
 

--- a/recipyCommon/magic.py
+++ b/recipyCommon/magic.py
@@ -1,0 +1,37 @@
+from IPython.core.magic import (Magics, magics_class, line_magic,
+                                cell_magic, line_cell_magic)
+
+# The class MUST call this class decorator at creation time
+@magics_class
+class RecipyMagic(Magics):
+    def __init__(self, shell):
+        super(RecipyMagic, self).__init__(shell)
+        self.recipyModule = None
+
+    @line_magic
+    def recipyOn(self, line):
+        "my line magic"
+        # print("Full access to the main IPython object:", self.shell)
+        # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
+        print("[RecipyMagic] this is when recipy should bet imported, not before...")
+        import recipy
+        self.recipyModule = recipy
+        return None
+
+    @line_magic
+    def recipyOff(self, line):
+        "my line magic"
+        # print("Full access to the main IPython object:", self.shell)
+        # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
+        self.recipyModule.log_flush()
+        return None
+
+def load_ipython_extension(ipython):
+    # The `ipython` argument is the currently active `InteractiveShell`
+    # instance, which can be used in any way. This allows you to register
+    # new magics or aliases, for example.
+    ipython.register_magics(RecipyMagic)
+
+def unload_ipython_extension(ipython):
+    # If you want your extension to be unloadable, put that logic here.
+    pass

--- a/recipyCommon/magic.py
+++ b/recipyCommon/magic.py
@@ -1,5 +1,6 @@
 from IPython.core.magic import (Magics, magics_class, line_magic,
                                 cell_magic, line_cell_magic)
+import time
 
 # The class MUST call this class decorator at creation time
 @magics_class
@@ -8,13 +9,50 @@ class RecipyMagic(Magics):
         super(RecipyMagic, self).__init__(shell)
         self.recipyModule = None
 
+    def loadNotebookName_js(self):
+        cell = '''
+%%javascript
+
+var kernel = IPython.notebook.kernel;
+var attribs = document.body.attributes;
+var command = "recipyNotebookName = " + "'"+attribs['data-notebook-name'].value+"'";
+console.log("Load notebook name...")
+kernel.execute(command);
+'''
+        r = self.shell.run_cell(cell)
+        # x = 1/0
+        #return None
+        return r
+
+    def getNotebookName(self):
+        retries = 5
+        while retries > 0:
+            if 'recipyNotebookName' in self.shell.user_ns:
+                return self.shell.user_ns['recipyNotebookName']
+            else:
+                retries -= 1
+                time.sleep(1)
+        return None
+
+
+    @line_magic
+    def loadNotebookName(self, line):
+        "my line magic"
+        # print("Full access to the main IPython object:", self.shell)
+        # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
+        self.loadNotebookName_js()
+        return None
+
     @line_magic
     def recipyOn(self, line):
         "my line magic"
         # print("Full access to the main IPython object:", self.shell)
         # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
+        notebookName = self.getNotebookName()
         print("[RecipyMagic] this is when recipy should bet imported, not before...")
+        print("[RecipyMagic] notebookName: " + notebookName)
         import recipy
+        recipy.log_init(notebookName='TestRecipyMagic.ipynb')
         self.recipyModule = recipy
         return None
 


### PR DESCRIPTION
Adding recipy support for jupyter notebooks.

Recipy support can be activated via one magic command and deactivated at the end. In this way, a whole notebook can be logged or just a few execution cells.

TestRecipyMagic.ipynb contains an example of how magic should be used.