### PR TITLE
Add default conversion to dumps

### DIFF
--- a/recipyGui/views.py
+++ b/recipyGui/views.py
@@ -119,7 +119,7 @@ def runs2json():
     runs = [db.get(eid=run_id) for run_id in run_ids]
     db.close()
 
-    response = make_response(dumps(runs, indent=2, sort_keys=True))
+    response = make_response(dumps(runs, indent=2, sort_keys=True, default=unicode))
     response.headers['content-type'] = 'application/json'
     response.headers['Content-Disposition'] = 'attachment; filename=runs.json'
     return response


### PR DESCRIPTION
Added default converter to dumps to avoid serialization error for
datetime.datetime in gui. e.g.:

~~~
TypeError: datetime.datetime(2017, 4, 11, 22, 50, 18) is not JSON serializable
~~~ 