### PR TITLE
Make all tests pass for all Python versions on both AppVeyor and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,18 +27,18 @@ install:
   # Miniconda is recommended as the way to install these. See also:
   # http://conda.pydata.org/docs/travis.html
   # The following adopts approaches suggested in the above links.
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION \
-    pytest behave \
-    python-dateutil pyyaml numpy git \
-    matplotlib \
-    pandas pytables xlrd xlwt \
-    lxml \
-    beautifulsoup4 \
-    pillow \
-    scikit-learn \
-    scikit-image \
-    nibabel \
-    gdal imageio tifffile xarray rasterio netCDF4 \
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+    pytest behave
+    python-dateutil pyyaml numpy git
+    matplotlib
+    pandas pytables xlrd xlwt
+    lxml
+    beautifulsoup4
+    pillow
+    scikit-learn
+    scikit-image
+    nibabel
+    gdal imageio tifffile xarray rasterio netCDF4
     iris
   - source activate test-environment
   # Copy matplotlib configuration so it does not try and plot to

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   # http://conda.pydata.org/docs/travis.html
   # The following adopts approaches suggested in the above links.
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    pytest behave
+    pytest
     python-dateutil pyyaml numpy git
     matplotlib
     pandas pytables xlrd xlwt
@@ -59,8 +59,6 @@ install:
 
 
 script:
-  - cd test/ && behave
-  - cd ..
   # Run py.test with 'v' (verbose) to show test function names and
   # 'rs' to show reasons for skipped tests
   - py.test -v -rs integration_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda config --prepend channels conda-forge
+  # - conda config --prepend channels conda-forge
   - conda update -q conda
   - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  # - conda config --prepend channels conda-forge
+  - conda config --prepend channels conda-forge
   - conda update -q conda
   - conda info -a
 
@@ -27,24 +27,20 @@ install:
   # Miniconda is recommended as the way to install these. See also:
   # http://conda.pydata.org/docs/travis.html
   # The following adopts approaches suggested in the above links.
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION \
+    pytest behave \
+    python-dateutil pyyaml numpy git \
+    matplotlib \
+    pandas pytables xlrd xlwt \
+    lxml \
+    beautifulsoup4 \
+    pillow \
+    scikit-learn \
+    scikit-image \
+    nibabel \
+    gdal imageio tifffile xarray rasterio netCDF4 \
+    iris
   - source activate test-environment
-  # Install py.test explicitly else Travis CI will use the one in its
-  # virtualenv which can't use the Miniconda environment.
-  - conda install pytest behave
-  # Install packages needed for testing recipy.
-  - conda install python-dateutil pyyaml numpy git
-  # Install packages that recipy can log.
-  - conda install matplotlib
-  - conda install pandas pytables xlrd xlwt
-  - conda install lxml
-  - conda install beautifulsoup4
-  - conda install pillow
-  - conda install scikit-learn
-  - conda install scikit-image
-  - conda install nibabel
-  - conda install gdal imageio tifffile xarray rasterio netCDF4
-  - conda install -c conda-forge iris
   # Copy matplotlib configuration so it does not try and plot to
   # screen, which can cause matplotlib tests to fail.
   - cp integration_test/packages/matplotlibrc .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - conda config --prepend channels conda-forge
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - "conda create -q -n test-environment python=%PYTHON_VERSION%
     pytest
     python-dateutil pyyaml numpy git
     matplotlib
@@ -39,7 +39,7 @@ install:
     scikit-image
     nibabel
     gdal imageio tifffile xarray rasterio netCDF4
-    iris
+    iris"
   - activate test-environment
   # Copy matplotlib configuration so it does not try and plot to 
   # screen, which can cause matplotlib tests to fail.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,24 +27,20 @@ install:
   - conda config --prepend channels conda-forge
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION%"
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+    pytest
+    python-dateutil pyyaml numpy git
+    matplotlib
+    pandas pytables xlrd xlwt
+    lxml
+    beautifulsoup4
+    pillow
+    scikit-learn
+    scikit-image
+    nibabel
+    gdal imageio tifffile xarray rasterio netCDF4
+    iris
   - activate test-environment
-
-  # Install py.test explicitly else Travis CI will use the one in its
-  # virtualenv which can't use the Miniconda environment.
-  - conda install pytest behave
-  # Install packages needed for testing recipy.
-  - conda install python-dateutil pyyaml numpy git
-  # Install packages that recipy can log.
-  - conda install matplotlib
-  - conda install pandas pytables xlrd xlwt
-  - conda install lxml
-  - conda install beautifulsoup4
-  - conda install pillow
-  - conda install scikit-learn
-  - conda install scikit-image
-  - pip install nibabel
-  - conda install gdal imageio tifffile xarray rasterio netCDF4 iris
   # Copy matplotlib configuration so it does not try and plot to 
   # screen, which can cause matplotlib tests to fail.
   - copy integration_test\packages\matplotlibrc .
@@ -55,6 +51,7 @@ install:
   - which pip
   - which py.test
   - py.test --version
+  - python --version
   - pip freeze
 
 test_script:

--- a/integration_test/config/test_packages.yml
+++ b/integration_test/config/test_packages.yml
@@ -29,11 +29,14 @@ libraries: [ gdal ]
 test_cases:
 - arguments: [ open ]
   inputs: [ image.tiff ]
+  skip_py_version: [ 3.4 ]
 - arguments: [ driver_create ]
   outputs: [ out_image.tiff ]
+  skip_py_version: [ 3.4 ]
 - arguments: [ driver_createcopy ]
   inputs: [ image.tiff ]
   outputs: [ out_image.tiff ]
+  skip_py_version: [ 3.4 ]
 ---
 script: run_skimage.py
 libraries: [ skimage ]

--- a/integration_test/config/test_packages.yml
+++ b/integration_test/config/test_packages.yml
@@ -133,8 +133,10 @@ libraries: [ lxml ]
 test_cases:
 - arguments: [ parse ]
   inputs: [ data.xml ]
+  skip_py_version: [ 3.4 ]
 - arguments: [ iterparse ]
   inputs: [ data.xml ]
+  skip_py_version: [ 3.4 ]
 ---
 script: run_bs4.py
 libraries: [ bs4 ]

--- a/integration_test/environment.py
+++ b/integration_test/environment.py
@@ -129,6 +129,9 @@ def get_packages():
         modules_from_package = package._get_metadata('top_level.txt')
         for mod in modules_from_package:
             packages_dict[mod] = package.version
+
+        packages_dict[package.key] = package.version
+        packages_dict[package.project_name] = package.version
     return packages_dict
 
 

--- a/integration_test/packages/run_iris.py
+++ b/integration_test/packages/run_iris.py
@@ -89,11 +89,10 @@ class IrisSample(Base):
         """
         Use iris.save to save data to a netcdf file.
         """
-        data = xarray.DataArray(np.random.randn(2, 3))
-        dt = data.to_iris()
+        cube = iris.cube.Cube(data=np.random.randn(2, 3))
 
         file_name = os.path.join(self.data_dir, "cube.nc")
-        iris.save(dt, file_name)
+        iris.save(cube, file_name)
 
         os.remove(file_name)
 

--- a/integration_test/packages/run_iris.py
+++ b/integration_test/packages/run_iris.py
@@ -13,7 +13,6 @@ import recipy
 import os
 import sys
 import iris
-import xarray
 import numpy as np
 
 from integration_test.packages.base import Base

--- a/integration_test/packages/run_tifffile.py
+++ b/integration_test/packages/run_tifffile.py
@@ -46,11 +46,10 @@ class TifffileSample(Base):
         """
         Use tifffile.imsave to write image2.tiff.
         """
-        #file_name_in = os.path.join(self.data_dir, "image.tiff")
         file_name = os.path.join(self.data_dir, "image2.tiff")
 
-        data = numpy.array([1, 2, 3])
-        #im = tifffile.imread(file_name_in)
+        data = numpy.array([[1, 2, 3],
+                            [4, 5, 6]])
 
         tifffile.imsave(file_name, data)
         os.remove(file_name)


### PR DESCRIPTION
Previously tests were failing on Python 3.4 on both Travis (Linux) and AppVeyor (Windows). To fix this, I have:

 - Skipped the GDAL tests on Python 3.4 as there is no working Python 3.4 compatible GDAL available through conda
 - Skipped the lxml tests on Python 3.4 as there are library issues getting lxml working with unicode properly through conda
 - Changed the way that the dictionary of installed packages is created in the test framework, so that it picks up old versions of the numpy package properly
 - Changed the way that the conda environment is set up so that all packages are installed in one transaction thus 1) forcing an error if those packages can't be installed on the selected python version (rather than just silently upgrading/downgrading python) and 2) ensuring all installs are fully compatible with each other. This is done on both Travis and AppVeyor.
 - Changed the iris package tests to not depend on xarray, so that we can skip xarray tests on Python 3.4 but still do iris tests